### PR TITLE
Fix JENKINS-9116

### DIFF
--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
@@ -155,7 +155,8 @@ public class DescriptionSetterPublisher extends Recorder implements
 
         // Expand all groups: 1..Count, as well as 0 for the entire pattern
 		for (int i = matcher.groupCount(); i >= 0; i--) {
-			result = result.replace("\\" + i, matcher.group(i));
+			result = result.replace("\\" + i, 
+					matcher.group(i) == null ? "" : matcher.group(i));
 		}
 		return result;
 	}

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
@@ -91,6 +91,20 @@ public class DescriptionSetterPublisherTest extends HudsonTestCase {
 				Result.SUCCESS, "url:(.*)", null, null,
 				null));
 	}
+	
+	public void testNullMatch1() throws Exception {
+		assertEquals("Match=(MatchOne) MatchTwo",
+				getDescription("Prefix: MatchOne MatchTwo", Result.SUCCESS,
+						"^Prefix: (\\S+)( .*)?$", null, 
+						"Match=(\\1)\\2", null));
+	}
+
+	public void testNullMatch2() throws Exception {
+		assertEquals("Match=(MatchOne)",
+				getDescription("Prefix: MatchOne", Result.SUCCESS,
+						"^Prefix: (\\S+)( .*)?$", null,
+						"Match=(\\1)\\2", null));
+	}
 
 	private String getDescription(String text, Result result, String regexp,
 			String regexpForFailed, String description,


### PR DESCRIPTION
Handle group matches that are null.  This can arise when you have ( )? or disjunction in your regex.
