### PR TITLE
[JENKINS-24398] Support for Token Macro Plugin in description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,6 +12,15 @@
   <name>Jenkins description setter plugin</name>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Description+Setter+Plugin</url>
 
+  <dependencies>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>token-macro</artifactId>
+      <version>1.5.1</version>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
   <developers>
     <developer>
       <id>huybrechts</id>

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -2,6 +2,8 @@ package hudson.plugins.descriptionsetter;
 
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -47,7 +49,11 @@ public class DescriptionSetterHelper {
 				result = build.getEnvironment(listener).expand(result);
 			} else {
 				if (result == null && regexp == null && description != null) {
-					result = description;
+                    try {
+                        result = TokenMacro.expandAll(build, listener, description);
+                    } catch (MacroEvaluationException e) {
+                        listener.getLogger().println(e.getMessage());
+                    }
 				}
 			}
 

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -2,7 +2,7 @@ package hudson.plugins.descriptionsetter;
 
 import hudson.model.BuildListener;
 import hudson.model.AbstractBuild;
-import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import jenkins.model.Jenkins;
 import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
 import java.io.BufferedReader;
@@ -48,12 +48,16 @@ public class DescriptionSetterHelper {
 				result = getExpandedDescription(matcher, description);
 				result = build.getEnvironment(listener).expand(result);
 			} else {
-				if (result == null && regexp == null && description != null) {
-                    try {
-                        result = TokenMacro.expandAll(build, listener, description);
-                    } catch (MacroEvaluationException e) {
-                        listener.getLogger().println(e.getMessage());
-                    }
+				if (result == null && (regexp == null || regexp.isEmpty()) && description != null) {
+                    if (Jenkins.getInstance().getPlugin("token-macro") != null) {
+                        try {
+                            result = TokenMacro.expandAll(build, listener, description);
+                        } catch (Exception e) {
+                            listener.getLogger().println(e.getMessage());
+                        }
+                    } else
+                        result = description;
+                        listener.getLogger().print("Macros cannot be expanded as Token Macro Plugin is not installed. Please install the Token Macro plugin to use macros.");
 				}
 			}
 
@@ -79,7 +83,7 @@ public class DescriptionSetterHelper {
 	private static Matcher parseLog(File logFile, String regexp)
 			throws IOException, InterruptedException {
 
-		if (regexp == null) {
+		if (regexp == null || regexp.isEmpty()) {
 			return null;
 		}
 

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help-description.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help-description.html
@@ -3,5 +3,5 @@
 	<ul>
 	<li>If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match.</li>
 	<li>If the description is empty, the first group selected by the regular expression will be used as description.</li>
-	<li>If no regular expression is configured, the description is taken verbatim.</li>
+	<li>If no regular expression is configured, the description is taken verbatim. If the token macro plugin is installed, macros are expanded.</li>
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-description.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-description.html
@@ -3,5 +3,5 @@
 	<ul>
 	<li>If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match.</li>
 	<li>If the description is empty, the first group selected by the regular expression will be used as description.</li>
-	<li>If no regular expression is configured, the description is taken verbatim.</li>
+	<li>If no regular expression is configured, the description is taken verbatim. If the token macro plugin is installed, macros are expanded.</li>
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help.html
@@ -3,6 +3,6 @@
 	This plugin automatically sets a description for the build after it has completed.
 	</p>
 	<p>
-	A description can be based on the log output (by searching it using a regular expression), or it can be hardcoded.
+	A description can be based on the log output (by searching it using a regular expression), or it can be hardcoded. If no regular expression is configured and the <a href="https://wiki.jenkins-ci.org/display/JENKINS/Token+Macro+Plugin">Token Macro plugin</a> is installed macros specified in the description are expanded.
 	</p>
 </div>

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilderTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilderTest.java
@@ -39,6 +39,26 @@ public class DescriptionSetterBuilderTest extends HudsonTestCase {
 						"description success"));
 	}
 
+    public void testSuccessWithValidTokenMacro() throws Exception {
+        FreeStyleProject fooProject = createFreeStyleProject("foo");
+        fooProject.scheduleBuild2(0).get();
+
+        assertEquals(
+                "#1",
+                getDescription("xxx", Result.SUCCESS, null,
+                        "#${BUILD_NUMBER}"));
+    }
+
+    public void testSuccessWithInvalidTokenMacro() throws Exception {
+        FreeStyleProject fooProject = createFreeStyleProject("foo");
+        fooProject.scheduleBuild2(0).get();
+
+        assertEquals(
+                null,
+                getDescription("xxx", Result.SUCCESS, null,
+                        "${xxx}"));
+    }
+
 	public void testSuccessNoMatch() throws Exception {
 		assertEquals(
 				null,

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
@@ -18,10 +18,10 @@ public class DescriptionSetterPublisherTest extends HudsonTestCase {
 				Result.SUCCESS, "text (.*)", null, "description \\1", null));
 	}
 
-        public void testSuccessConfiguredDescription2() throws Exception {
-		assertEquals("description one two", getDescription("text one two",
-				Result.SUCCESS, "text (\\w+) (\\w+)", null, "description \\1 \\2", null));
-        }
+    public void testSuccessConfiguredDescription2() throws Exception {
+        assertEquals("description one two", getDescription("text one two",
+            Result.SUCCESS, "text (\\w+) (\\w+)", null, "description \\1 \\2", null));
+    }
 
 	public void testFailureWithNoFailureRegex() throws Exception {
 		assertEquals("one", getDescription("text one", Result.FAILURE,
@@ -50,6 +50,38 @@ public class DescriptionSetterPublisherTest extends HudsonTestCase {
 				Result.FAILURE, null, null, "description success",
 				"description failure"));
 	}
+
+    public void testSuccessWithValidTokenMacro() throws Exception {
+        FreeStyleProject fooProject = createFreeStyleProject("foo");
+        fooProject.scheduleBuild2(0).get();
+
+        assertEquals("#1", getDescription("xxx",
+                Result.SUCCESS, null, null, "#${BUILD_NUMBER}", null));
+    }
+
+    public void testSuccessWithInvalidTokenMacro() throws Exception {
+        FreeStyleProject fooProject = createFreeStyleProject("foo");
+        fooProject.scheduleBuild2(0).get();
+
+        assertEquals(null, getDescription("xxx",
+                Result.SUCCESS, null, null, "${xxx}", null));
+    }
+
+    public void testFailureWithValidTokenMacro() throws Exception {
+        FreeStyleProject fooProject = createFreeStyleProject("foo");
+        fooProject.scheduleBuild2(0).get();
+
+        assertEquals("#1", getDescription("xxx",
+                Result.FAILURE, null, null, null, "#${BUILD_NUMBER}"));
+    }
+
+    public void testFailureWithInvalidTokenMacro() throws Exception {
+        FreeStyleProject fooProject = createFreeStyleProject("foo");
+        fooProject.scheduleBuild2(0).get();
+
+        assertEquals(null, getDescription("xxx",
+                Result.FAILURE, null, null, null, "${xxx}"));
+    }
 
 	public void testSuccessNoMatch() throws Exception {
 		assertEquals(null, getDescription("xxx",


### PR DESCRIPTION
Supports to expansion of macros provided via the token macro plugin.
Macros are expanded only if no regex is given.
