### PR TITLE
Add support for multiline patterns

### DIFF
--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -83,11 +83,15 @@ public class DescriptionSetterHelper {
 		BufferedReader reader = null;
 		try {
 			reader = new BufferedReader(new FileReader(logFile));
+			String logContent = "";
+
 			while ((line = reader.readLine()) != null) {
-				Matcher matcher = pattern.matcher(line);
-				if (matcher.find()) {
-					return matcher;
-				}
+				logContent += line + "\n";
+			}
+
+			Matcher matcher = pattern.matcher(logContent);
+			if (matcher.find()) {
+				return matcher;
 			}
 		} finally {
 			if (reader != null) {


### PR DESCRIPTION
Changed the `parseLog()` function to read the entire log file, so that the regular expression can match on multiple lines.

Our Jenkins server uses this to set the build description to be the same as the Git commit message (using `git log --format=%B -n 1 HEAD`).

The log is read one line at a time and appended into a single string. This is probably horribly inefficient, but I'm not very fluent in Java, so it's good enough for our purposes.

It also reads the entire file before trying to match the pattern, but on the other hand, the match is attempted only once (as opposed to once for every line).

NOTE: Some tests failed for me, even with unmodified sources, so I compiled without tests (`mvn install -Dmaven.test.skip=true`).
