### PR TITLE
[JENKINS-26671] Multiple description setter build steps should append

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 description-setter.iml
 target/
+work/
+.project
+.classpath
+.settings

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -1,7 +1,11 @@
 package hudson.plugins.descriptionsetter;
 
+import hudson.EnvVars;
 import hudson.model.BuildListener;
+import hudson.model.ParameterValue;
 import hudson.model.AbstractBuild;
+import hudson.model.ParametersAction;
+import hudson.model.StringParameterValue;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -9,6 +13,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -70,7 +76,9 @@ public class DescriptionSetterHelper {
 				String newDescr = oldDescr + "<br />" + result;
 				build.setDescription(newDescr);
 			}
-			
+
+			setEnvironmentVariable(result, build);
+
 			listener.getLogger().println(LOG_PREFIX + " Description set: " + result);
 		} catch (IOException e) {
 			e.printStackTrace(listener.error(LOG_PREFIX
@@ -78,6 +86,13 @@ public class DescriptionSetterHelper {
 		}
 
 		return true;
+	}
+	
+	private static void setEnvironmentVariable(String result, AbstractBuild<?, ?> build)
+	{
+		List<ParameterValue> params = new ArrayList<ParameterValue>();
+		params.add(new StringParameterValue("DESCRIPTION_SETTER_DESCRIPTION", result));
+		build.addAction(new ParametersAction(params));
 	}
 
 	private static Matcher parseLog(File logFile, String regexp)

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -60,7 +60,17 @@ public class DescriptionSetterHelper {
 			result = urlify(result);
 
 			build.addAction(new DescriptionSetterAction(result));
-			build.setDescription(result);
+			if(build.getDescription() == null)
+			{
+				build.setDescription(result);
+			}
+			else
+			{
+				String oldDescr = build.getDescription();
+				String newDescr = oldDescr + "<br />" + result;
+				build.setDescription(newDescr);
+			}
+			
 			listener.getLogger().println(LOG_PREFIX + " Description set: " + result);
 		} catch (IOException e) {
 			e.printStackTrace(listener.error(LOG_PREFIX

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
@@ -156,6 +156,12 @@ public class DescriptionSetterPublisher extends Recorder implements
 						&& run.getDescription() != null) {
 					build.setDescription(run.getDescription());
 				}
+				else if(build.getDescription() != null && run.getDescription() != null)
+				{
+					String oldDescr = build.getDescription();
+					String newDescr = oldDescr + "<br />" + run.getDescription();
+					build.setDescription(newDescr);
+				}
 				return true;
 			}
 		};

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help-description.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help-description.html
@@ -4,4 +4,5 @@
 	<li>If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match.</li>
 	<li>If the description is empty, the first group selected by the regular expression will be used as description.</li>
 	<li>If no regular expression is configured, the description is taken verbatim.</li>
+	</ul>
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help.html
@@ -5,4 +5,7 @@
 	<p>
 	A description can be based on the log output (by searching it using a regular expression), or it can be hardcoded.
 	</p>
+	<p>
+	The description is exposed as DESCRIPTION_SETTER_DESCRIPTION environment variable
+	</p>
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-description.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-description.html
@@ -4,4 +4,5 @@
 	<li>If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match.</li>
 	<li>If the description is empty, the first group selected by the regular expression will be used as description.</li>
 	<li>If no regular expression is configured, the description is taken verbatim.</li>
+	</ul>
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-regexpForFailed.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-regexpForFailed.html
@@ -1,3 +1,3 @@
 <div>
-  If set, this regular expression will be used instead of the regular regular expression when the build has failed.
+  If set, this regular expression will be used in case no hardcoded description is configured, when the build has failed.
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help.html
@@ -5,4 +5,7 @@
 	<p>
 	A description can be based on the log output (by searching it using a regular expression), or it can be hardcoded.
 	</p>
+	<p>
+	The description is exposed as DESCRIPTION_SETTER_DESCRIPTION environment variable
+	</p>
 </div>


### PR DESCRIPTION
...

This commit fixes [JENKINS-26671]: Multiple description setter build
steps
should append to build description]
At the same time it also fixes [JENKINS-14198]: Ability to append a
description to existing description for use with flexible publish