### PR TITLE
Fix description environment variable security issue.

### DIFF
--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilder.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilder.java
@@ -24,12 +24,14 @@ public class DescriptionSetterBuilder extends Builder {
 	private final String regexp;
 	private final String description;
 	private final boolean appendMode;
+	private final boolean envVariable;
 
 	@DataBoundConstructor
-	public DescriptionSetterBuilder(String regexp, String description, boolean appendMode) {
+	public DescriptionSetterBuilder(String regexp, String description, boolean appendMode, boolean envVariable) {
 		this.regexp = regexp;
 		this.description = Util.fixEmptyAndTrim(description);
 		this.appendMode = appendMode;
+		this.envVariable = envVariable;
 	}
 
 	@Override
@@ -37,7 +39,7 @@ public class DescriptionSetterBuilder extends Builder {
 			BuildListener listener) throws InterruptedException {
 
 		return DescriptionSetterHelper.setDescription(build, listener, regexp,
-				description, appendMode);
+				description, appendMode, envVariable);
 	}
 
 	@Extension

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -41,7 +41,7 @@ public class DescriptionSetterHelper {
 	public static boolean setDescription(AbstractBuild<?, ?> build,
 			BuildListener listener, String regexp, String description)
 			throws InterruptedException {
-		return setDescription(build, listener, regexp, description, true);
+		return setDescription(build, listener, regexp, description, true, true);
 	}
 
 	/**
@@ -53,12 +53,14 @@ public class DescriptionSetterHelper {
 	 * @param regexp the regular expression to apply to the build log.
 	 * @param description the description to set.
 	 * @param appendMode if true, description is added to the current one
+	 * @param envVariable if true, environment variable containing the
+	 *         description is set.
 	 * @return true, regardless of if the regular expression matched and a
 	 *         description could be set or not.
 	 * @throws InterruptedException if the build is interrupted by the user.
 	 */
 	public static boolean setDescription(AbstractBuild<?, ?> build,
-			BuildListener listener, String regexp, String description, boolean appendMode)
+			BuildListener listener, String regexp, String description, boolean appendMode, boolean envVariable)
 			throws InterruptedException {
 		try {
 			Matcher matcher;
@@ -88,7 +90,9 @@ public class DescriptionSetterHelper {
 			else
 				build.setDescription((appendMode ? build.getDescription() + "<br />" : "") + result);
 
-			setEnvironmentVariable(result, build);
+			if(envVariable) {
+				setEnvironmentVariable(result, build);
+			}
 
 			listener.getLogger().println(LOG_PREFIX + " Description set: " + result);
 		} catch (IOException e) {

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
@@ -40,6 +40,7 @@ public class DescriptionSetterPublisher extends Recorder implements
 	private final String descriptionForFailed;
 	private final boolean setForMatrix;
 	private final boolean appendMode;
+	private final boolean envVariable;
 
 	@Deprecated
 	private transient boolean setForFailed = false;
@@ -50,13 +51,14 @@ public class DescriptionSetterPublisher extends Recorder implements
 	@DataBoundConstructor
 	public DescriptionSetterPublisher(String regexp, String regexpForFailed,
 			String description, String descriptionForFailed,
-			boolean setForMatrix, boolean appendMode) {
+			boolean setForMatrix, boolean appendMode, boolean envVariable) {
 		this.regexp = regexp;
 		this.regexpForFailed = regexpForFailed;
 		this.description = Util.fixEmptyAndTrim(description);
 		this.descriptionForFailed = Util.fixEmptyAndTrim(descriptionForFailed);
 		this.setForMatrix = setForMatrix;
 		this.appendMode = appendMode;
+		this.envVariable = envVariable;
 	}
 
 	public BuildStepMonitor getRequiredMonitorService() {
@@ -72,13 +74,13 @@ public class DescriptionSetterPublisher extends Recorder implements
 		return DescriptionSetterHelper.setDescription(build, listener,
 				useUnstable ? regexpForFailed : regexp,
 				useUnstable ? descriptionForFailed : description,
-				appendMode);
+				appendMode, envVariable);
 	}
 
 	private Object readResolve() throws ObjectStreamException {
 		if (explicitNotRegexp) {
 			return new DescriptionSetterPublisher(null, null, regexp,
-					setForFailed ? regexpForFailed : null, false, false);
+					setForFailed ? regexpForFailed : null, false, false, true);
 		} else {
 			return this;
 		}

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/config.jelly
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/config.jelly
@@ -9,4 +9,7 @@
 	<f:entry title="${%Append to description instead of resetting it}" field="appendMode">
 		<f:checkbox />
 	</f:entry>
+	<f:entry title="${%Add Environment Variable}" field="envVariable">
+		<f:checkbox default="true" />
+	</f:entry>
 </j:jelly>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help.html
@@ -6,6 +6,6 @@
 	A description can be based on the log output (by searching it using a regular expression), or it can be hardcoded.
 	</p>
 	<p>
-	The description is exposed as DESCRIPTION_SETTER_DESCRIPTION environment variable
+	Optionally, the description is exposed as DESCRIPTION_SETTER_DESCRIPTION environment variable (considered insecure on Jenkins 2)
 	</p>
 </div>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/config.jelly
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/config.jelly
@@ -21,6 +21,9 @@
 		<f:entry title="${%Append to description instead of resetting it}" field="appendMode">
 			<f:checkbox />
 		</f:entry>
+		<f:entry title="${%Add Environment Variable}" field="envVariable">
+			<f:checkbox default="true" />
+		</f:entry>		
 	</f:advanced>
 
 </j:jelly>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help.html
@@ -6,6 +6,6 @@
 	A description can be based on the log output (by searching it using a regular expression), or it can be hardcoded.
 	</p>
 	<p>
-	The description is exposed as DESCRIPTION_SETTER_DESCRIPTION environment variable
+	Optionally, the description is exposed as DESCRIPTION_SETTER_DESCRIPTION environment variable (considered insecure on Jenkins 2)
 	</p>
 </div>

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilderTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilderTest.java
@@ -69,16 +69,16 @@ public class DescriptionSetterBuilderTest extends HudsonTestCase {
 
 	public void testAppendDescriptionInBuilder() throws Exception {
 		FreeStyleProject project = createFreeStyleProject();
-		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false));
-		project.getBuildersList().add(new DescriptionSetterBuilder("", "test2", true));
+		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false, true));
+		project.getBuildersList().add(new DescriptionSetterBuilder("", "test2", true, true));
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 		assertEquals("test1<br />test2", build.getDescription());
 	}
 
 	public void testRewriteDescriptionInBuilder() throws Exception {
 		FreeStyleProject project = createFreeStyleProject();
-		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false));
-		project.getBuildersList().add(new DescriptionSetterBuilder("", "test2", false));
+		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false, true));
+		project.getBuildersList().add(new DescriptionSetterBuilder("", "test2", false, true));
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 		assertEquals("test2", build.getDescription());
 	}
@@ -88,7 +88,7 @@ public class DescriptionSetterBuilderTest extends HudsonTestCase {
 		FreeStyleProject project = createFreeStyleProject();
 		project.getBuildersList().add(new TestBuilder(text, result));
 		project.getBuildersList().add(
-				new DescriptionSetterBuilder(regexp, description, appendMode));
+				new DescriptionSetterBuilder(regexp, description, appendMode, true));
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 		return build.getDescription();
 	}

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
@@ -79,18 +79,18 @@ public class DescriptionSetterPublisherTest extends HudsonTestCase {
 
 	public void testAppendDescriptionInPublisher() throws Exception {
 		FreeStyleProject project = createFreeStyleProject();
-		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false));
+		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false, true));
 		project.getPublishersList().add(
-				new DescriptionSetterPublisher("", "", "test2", "", false, true));
+				new DescriptionSetterPublisher("", "", "test2", "", false, true, true));
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 		assertEquals("test1<br />test2", build.getDescription());
 	}
 
 	public void testRewriteDescriptionInPublisher() throws Exception {
 		FreeStyleProject project = createFreeStyleProject();
-		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false));
+		project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false, true));
 		project.getPublishersList().add(
-				new DescriptionSetterPublisher("", "", "test2", "", false, false));
+				new DescriptionSetterPublisher("", "", "test2", "", false, false, true));
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 		assertEquals("test2", build.getDescription());
 	}
@@ -102,7 +102,7 @@ public class DescriptionSetterPublisherTest extends HudsonTestCase {
 		project.getBuildersList().add(new TestBuilder(text, result));
 		project.getPublishersList().add(
 				new DescriptionSetterPublisher(regexp, regexpForFailed,
-						description, descriptionForFailed, false, appendMode));
+						description, descriptionForFailed, false, appendMode, true));
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
 		return build.getDescription();
 	}


### PR DESCRIPTION
Correct the warnings generated due to SECURITY-170 by making environment variable creation optional (https://issues.jenkins-ci.org/browse/JENKINS-43452)