### PR TITLE
Add an example of using \1 \2 in a description.

### DIFF
--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help-description.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterBuilder/help-description.html
@@ -2,6 +2,7 @@
 	The description to set on the build.
 	<ul>
 	<li>If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match.</li>
+	<li>For example:  Version:\1 Branch:\2</li>
 	<li>If the description is empty, the first group selected by the regular expression will be used as description.</li>
 	<li>If no regular expression is configured, the description is taken verbatim.</li>
 	</ul>

--- a/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-description.html
+++ b/src/main/resources/hudson/plugins/descriptionsetter/DescriptionSetterPublisher/help-description.html
@@ -2,6 +2,7 @@
 	The description to set on the build.
 	<ul>
 	<li>If a regular expression is configured, every instance of \n will be replaced with the n-th group of the regular expression match.</li>
+	<li>For example:  Version:\1 Branch:\2</li>
 	<li>If the description is empty, the first group selected by the regular expression will be used as description.</li>
 	<li>If no regular expression is configured, the description is taken verbatim.</li>
 	</ul>


### PR DESCRIPTION
I created this PR because it took me a while to figure out how to add a specific regex result into a description.  My brain saw the \n in the documentation as a newline, not a \ with n being a numeric variable.  Once I saw an example of usage I was fine, so I created this PR to try to update the documentation to help other people avoid this confusion. 