### PR TITLE
Restore plugin groupId

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,51 +1,58 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.jenkins-ci.plugins</groupId>
-        <artifactId>plugin</artifactId>
-        <version>4.76</version>
-        <relativePath />
-    </parent>
-    <groupId>io.jenkins.plugins</groupId>
-    <artifactId>description-setter</artifactId>
-    <version>${revision}${changelist}</version>
-    <packaging>hpi</packaging>
-    <properties>
-        <revision>1.11</revision>
-        <changelist>-SNAPSHOT</changelist>
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.jenkins-ci.plugins</groupId>
+    <artifactId>plugin</artifactId>
+    <version>4.76</version>
+    <relativePath />
+  </parent>
 
-        <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
-        <jenkins.version>2.401.3</jenkins.version>
-        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <spotbugs.effort>Max</spotbugs.effort>
-        <spotbugs.threshold>Low</spotbugs.threshold>
-    </properties>
-    <name>Jenkins description setter plugin</name>
+  <artifactId>description-setter</artifactId>
+  <version>${revision}${changelist}</version>
+  <packaging>hpi</packaging>
+  <name>Jenkins description setter plugin</name>
+  <url>https://github.com/jenkinsci/description-setter-plugin</url>
+
+  <developers>
+    <developer>
+       <id>michael1010</id>
+       <name>Michael</name>
+    </developer>
+    <developer>
+       <id>markewaite</id>
+       <name>Mark Waite</name>
+    </developer>
+  </developers>
+
+  <properties>
+    <revision>1.11</revision>
+    <changelist>-SNAPSHOT</changelist>
+
+    <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
+    <jenkins.version>2.401.3</jenkins.version>
+    <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    <spotbugs.effort>Max</spotbugs.effort>
+    <spotbugs.threshold>Low</spotbugs.threshold>
+  </properties>
+
+  <scm>
+    <connection>scm:git:https://github.com/jenkinsci/description-setter-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/description-setter-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/description-setter-plugin</url>
-    <developers>
-        <developer>
-            <id>michael1010</id>
-            <name>Michael</name>
-        </developer>
-    </developers>
+  </scm>
 
-    <scm>
-        <connection>scm:git:https://github.com/jenkinsci/description-setter-plugin.git</connection>
-        <developerConnection>scm:git:git@github.com:jenkinsci/description-setter-plugin.git</developerConnection>
-        <url>https://github.com/jenkinsci/description-setter-plugin</url>
-    </scm>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.401.x</artifactId>
-                <version>2705.vf5c48c31285b_</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom-2.401.x</artifactId>
+        <version>2705.vf5c48c31285b_</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
     <repositories>
         <repository>


### PR DESCRIPTION
## Restore plugin groupId

bbd7c15c5d84327c47ec56b64e292d579fa541d9 mistakenly changed the groupId from the original `org.jenkins-ci.plugins` to `io.jenkins.plugins`.

Detected because incrementals could not be delivered to wrong groupId.

### Testing done

Confirmed that hpi file generated by the build includes the same groupId as the hpi file released as 1.10.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
