### PR TITLE
[JENKINS-72555] Only include HTML br tag when using HTML formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>matrix-project</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>antisamy-markup-formatter</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <repositories>

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterHelper.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import jenkins.model.Jenkins;
 
 /**
  * Helper class that performs common functionality used by both
@@ -78,8 +79,13 @@ public class DescriptionSetterHelper {
             result = urlify(result);
 
             build.addAction(new DescriptionSetterAction(result));
+
+            /* Don't want a runtime dependency on OWASP markup formatter plugin */
+            String formatter = Jenkins.get().getMarkupFormatter().getClass().getName();
+            String htmlBreak = formatter.contains("HtmlMarkup") ? "<br>" : " ";
+
             if (build.getDescription() == null) build.setDescription(result);
-            else build.setDescription((appendMode ? build.getDescription() + "<br />" : "") + result);
+            else build.setDescription((appendMode ? build.getDescription() + htmlBreak : "") + result);
 
             setEnvironmentVariable(result, build);
 

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
@@ -19,6 +19,7 @@ import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import java.io.IOException;
 import java.io.ObjectStreamException;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
@@ -164,7 +165,11 @@ public class DescriptionSetterPublisher extends Recorder implements MatrixAggreg
                     build.setDescription(run.getDescription());
                 } else if (build.getDescription() != null && run.getDescription() != null) {
                     String oldDescr = build.getDescription();
-                    String newDescr = oldDescr + "<br />" + run.getDescription();
+                    /* Don't want a runtime dependency on OWASP markup formatter plugin */
+                    String formatter =
+                            Jenkins.get().getMarkupFormatter().getClass().getName();
+                    String htmlBreak = formatter.contains("HtmlMarkup") ? "<br>" : " ";
+                    String newDescr = oldDescr + htmlBreak + run.getDescription();
                     build.setDescription(newDescr);
                 }
                 return true;

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilderTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilderTest.java
@@ -1,8 +1,10 @@
 package hudson.plugins.descriptionsetter;
 
+import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.HudsonTestCase;
 
 public class DescriptionSetterBuilderTest extends HudsonTestCase {
@@ -57,7 +59,12 @@ public class DescriptionSetterBuilderTest extends HudsonTestCase {
         project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false));
         project.getBuildersList().add(new DescriptionSetterBuilder("", "test2", true));
         FreeStyleBuild build = project.scheduleBuild2(0).get();
-        assertEquals("test1<br />test2", build.getDescription());
+        assertEquals("test1 test2", build.getDescription());
+
+        /* Use the safe HTML markup formatter */
+        Jenkins.get().setMarkupFormatter(new RawHtmlMarkupFormatter(false));
+        FreeStyleBuild buildWithFormatter = project.scheduleBuild2(0).get();
+        assertEquals("test1<br>test2", buildWithFormatter.getDescription());
     }
 
     public void testRewriteDescriptionInBuilder() throws Exception {

--- a/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
+++ b/src/test/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisherTest.java
@@ -1,8 +1,10 @@
 package hudson.plugins.descriptionsetter;
 
+import hudson.markup.RawHtmlMarkupFormatter;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Result;
+import jenkins.model.Jenkins;
 import org.jvnet.hudson.test.HudsonTestCase;
 
 public class DescriptionSetterPublisherTest extends HudsonTestCase {
@@ -84,7 +86,12 @@ public class DescriptionSetterPublisherTest extends HudsonTestCase {
         project.getBuildersList().add(new DescriptionSetterBuilder("", "test1", false));
         project.getPublishersList().add(new DescriptionSetterPublisher("", "", "test2", "", false, true));
         FreeStyleBuild build = project.scheduleBuild2(0).get();
-        assertEquals("test1<br />test2", build.getDescription());
+        assertEquals("test1 test2", build.getDescription());
+
+        /* Use the safe HTML markup formatter */
+        Jenkins.get().setMarkupFormatter(new RawHtmlMarkupFormatter(false));
+        FreeStyleBuild buildWithFormatter = project.scheduleBuild2(0).get();
+        assertEquals("test1<br>test2", buildWithFormatter.getDescription());
     }
 
     public void testRewriteDescriptionInPublisher() throws Exception {


### PR DESCRIPTION
## [JENKINS-72555] Only include HTML br tag when using HTML formatter

[JENKINS-72555](https://issues.jenkins.io/browse/JENKINS-72555) reports that a literal 'br' tag is included in the output when a build description already exists and the description setter plugin is configured to append to the build description.

Only add the 'br' tag if the HTML markup formatter is being used.  Other marketup formatters exist, but the plugin does not attempt to adapt to those other markup formatters.

Intentionally does not create a runtime requirement on the OWASP markup formatter plugin because this plugin should not require a formatter plugin.

### Testing done

Automated tests extended to cover the new case.

Interactive tests confirm expected behavior with default formatter, safe HTML formatter, and markdown formatter.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
