### PR TITLE
[JENKINS-72702] Retain setting of the append checkbox

### DIFF
--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilder.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilder.java
@@ -77,4 +77,9 @@ public class DescriptionSetterBuilder extends Builder {
     public String getDescription() {
         return description;
     }
+
+    @SuppressWarnings("unused")
+    public boolean getAppendMode() {
+        return appendMode;
+    }
 }


### PR DESCRIPTION
This fixes https://issues.jenkins.io/browse/JENKINS-72702. According to https://wiki.jenkins.io/display/JENKINS/Basic+guide+to+Jelly+usage+in+Jenkins every object in a jelly file with a Descriptor needs to have either a getter or a public final field to allow the Jelly script to read the values to populate the configuration page
