### PR TITLE
Require Jenkins 2.479 and Jakarta EE 9

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,18 @@ Your pull request will be evaluated by the [Jenkins job](https://ci.jenkins.io/j
 
 Before submitting your change, please assure that you've added tests that verify the change.
 
+## Building and running the plugin
+
+The [plugin build process](https://www.jenkins.io/doc/developer/plugin-development/build-process/) is described in detail in the [plugin development chapter](https://www.jenkins.io/doc/developer/plugin-development/) of the [Jenkins developer guide](https://www.jenkins.io/doc/developer/).
+
+A development copy of the plugin can be run locally with the command:
+
+```
+mvn hpi:run
+```
+
+When submitting a pull request, please refer to the [plugin testing guidance](https://www.jenkins.io/doc/developer/plugin-development/plugin-release-tips/) in the Jenkins developer guide.
+
 ## Code formatting
 
 Source code and pom file formatting is maintained by the `spotless` maven plugin.

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <artifactId>description-setter</artifactId>
   <version>${changelist}</version>
   <packaging>hpi</packaging>
-  <name>Jenkins description setter plugin</name>
+  <name>Description Setter</name>
   <url>https://github.com/jenkinsci/description-setter-plugin</url>
 
   <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.88</version>
+    <version>5.6</version>
     <relativePath />
   </parent>
 
@@ -24,8 +24,8 @@
   <properties>
     <changelist>999999-SNAPSHOT</changelist>
     <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
-    <jenkins.baseline>2.452</jenkins.baseline>
-    <jenkins.version>${jenkins.baseline}.4</jenkins.version>
+    <jenkins.baseline>2.479</jenkins.baseline>
+    <jenkins.version>${jenkins.baseline}.1</jenkins.version>
     <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
     <spotbugs.effort>Max</spotbugs.effort>
     <spotbugs.threshold>Low</spotbugs.threshold>
@@ -37,7 +37,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-${jenkins.baseline}.x</artifactId>
-        <version>3944.v1a_e4f8b_452db_</version>
+        <version>4051.v78dce3ce8b_d6</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -14,17 +14,6 @@
   <name>Jenkins description setter plugin</name>
   <url>https://github.com/jenkinsci/description-setter-plugin</url>
 
-  <developers>
-    <developer>
-      <id>michael1010</id>
-      <name>Michael</name>
-    </developer>
-    <developer>
-      <id>markewaite</id>
-      <name>Mark Waite</name>
-    </developer>
-  </developers>
-
   <scm>
     <connection>scm:git:https://github.com/jenkinsci/description-setter-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/description-setter-plugin.git</developerConnection>

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilder.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterBuilder.java
@@ -11,7 +11,7 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * The DescriptionSetterBuilder allows the description of a build to be set as a
@@ -57,7 +57,7 @@ public class DescriptionSetterBuilder extends Builder {
         }
 
         @Override
-        public Builder newInstance(StaplerRequest req, @NonNull JSONObject formData) throws FormException {
+        public Builder newInstance(StaplerRequest2 req, @NonNull JSONObject formData) throws FormException {
             if (req == null) {
                 return null;
             }

--- a/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/DescriptionSetterPublisher.java
@@ -22,7 +22,7 @@ import java.io.ObjectStreamException;
 import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerRequest2;
 
 /**
  * The DescriptionSetterPublisher allows the description of a build to be set as
@@ -108,7 +108,7 @@ public class DescriptionSetterPublisher extends Recorder implements MatrixAggreg
         }
 
         @Override
-        public Publisher newInstance(StaplerRequest req, @NonNull JSONObject formData) throws FormException {
+        public Publisher newInstance(StaplerRequest2 req, @NonNull JSONObject formData) throws FormException {
             if (req == null) {
                 return null;
             }

--- a/src/main/java/hudson/plugins/descriptionsetter/JobByDescription.java
+++ b/src/main/java/hudson/plugins/descriptionsetter/JobByDescription.java
@@ -8,8 +8,8 @@ import hudson.model.JobProperty;
 import hudson.model.JobPropertyDescriptor;
 import hudson.model.Run;
 import net.sf.json.JSONObject;
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.StaplerRequest2;
+import org.kohsuke.stapler.StaplerResponse2;
 
 public class JobByDescription extends JobProperty<Job<?, ?>> {
 
@@ -36,7 +36,7 @@ public class JobByDescription extends JobProperty<Job<?, ?>> {
         }
 
         @Override
-        public JobProperty<?> newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+        public JobProperty<?> newInstance(StaplerRequest2 req, JSONObject formData) throws FormException {
             return new JobByDescription();
         }
     }
@@ -61,7 +61,7 @@ public class JobByDescription extends JobProperty<Job<?, ?>> {
             return "by-description";
         }
 
-        public Object getDynamic(String token, StaplerRequest req, StaplerResponse rsp) {
+        public Object getDynamic(String token, StaplerRequest2 req, StaplerResponse2 rsp) {
             for (Run<?, ?> run : owner.getBuilds()) {
                 DescriptionSetterAction action = run.getAction(DescriptionSetterAction.class);
                 if (action != null && token.equals(action.getDescription())) {


### PR DESCRIPTION
## Require Jenkins 2.479 and Jakarta EE 9

Jenkins 2.479.1 unclude Jakarta EE 9, Spring Security 6, and Eclipse Jetty 12.  It supports plugins that use Java EE 8, Spring Security 5, and Eclipse Jetty 10 with a compatibility layer.  We want to remove that compatibility layer in the future (as much as we can).  Update the plugin to use Jakarta EE 9, Spring Security 6, and Eclipse Jetty 12 without using the compatibility layer.

Also includes:

- Add runtime instructions to contributing guide
- Remove unused developers section from pom file
- Update plugin name capitalization

### Testing done

Confirmed that the Seed Jenkins plugin does not use any of the methods whose signatures are modified by this pull request.

Confirmed that automated tests pass

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
